### PR TITLE
Copyright reports with an ip only

### DIFF
--- a/copyright.schema.json
+++ b/copyright.schema.json
@@ -49,7 +49,7 @@
                                 }
                             },
                             "required": [
-                                "ReportClass", "ReportType", "InfringedMaterial", "InfringingUrl"
+                                "ReportClass", "ReportType", "InfringedMaterial"
                             ]
                         },
                         {


### PR DESCRIPTION
Some copyright reports can't add an url, eg. in some torrent reports. Therefore the field 'InfringingUrl' should be removed from the requirements.