### PR TITLE
Update current version in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Find the latest schema release [on the releases page](https://github.com/abusix/
 
 ## Current Version
 
-`1`
+`2`
 
-[Up-To-Date Tested Sample XARF Reports](samples/positive/1)
+[Up-To-Date Tested Sample XARF Reports](samples/positive/2)
 
 ## Build status
 


### PR DESCRIPTION
The current version is wrongly set as v1 in the ReadMe while v2 has already become the standard.

This extremely simple PR changes that.