### PR TITLE
Update codecov CI - allow for up to 1% drop in coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,6 @@ jobs:
           name: coverage
       - uses: codecov/codecov-action@v4
         with:
-          fail_ci_if_error: false # optional (default = false)
+          fail_ci_if_error: true # optional (default = false)
           verbose: true # optional (default = false)
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        # this allows a 1% drop from the previous base commit coverage
+        threshold: 1%


### PR DESCRIPTION
From what I've seen 1% should be enough for us to cover our bases and ensure that coverage doesn't drift too far. Though, I think we should revisit the coverage at some point.